### PR TITLE
Change order of operations between sorting and resetting index

### DIFF
--- a/ffdraftbuddy/app.py
+++ b/ffdraftbuddy/app.py
@@ -29,8 +29,8 @@ def load_fantasypros():
     return (
         pd.concat(all_df)
         .dropna(subset=["Player"])
-        .reset_index(drop=True)
         .sort_values(["Rank", "FPTS"], ascending=[True, False])
+        .reset_index(drop=True)
         [["Available", "Player", "Team", "Position", "Rank", "FPTS"]]
     )
 


### PR DESCRIPTION
When marking off players as unavailable, there seems to be a mismatch in the associated index, so the modified dataframe marks the incorrect player as unavailable. This appears to be a consequence of how sorting vs indexing is performed in sequence